### PR TITLE
Changed label format more specifically

### DIFF
--- a/EmployerInfoSessions/sessions.py
+++ b/EmployerInfoSessions/sessions.py
@@ -53,9 +53,9 @@ for month in ["2014Jan", "2014Feb", "2014Mar"]:
 	for i in range(0, len(employers)):
 		session = {}
 		if i < idOffset:
-            session["id"] = ""
-        else:
-            session["id"] = ids[i - idOffset]
+			session["id"] = ""
+		else:
+			session["id"] = ids[i - idOffset]
 		session["employer"] = employers[i]
 		session["date"] = dates[i]
 		session["start_time"] = times[i][0]


### PR DESCRIPTION
To avoid “others” (like description) include label key word and leading
get_by_label return wrong informations
