### PR TITLE
New version of Buildings.csv which matches IAP's list.

### DIFF
--- a/Buildings/Buildings.csv
+++ b/Buildings/Buildings.csv
@@ -1,181 +1,238 @@
-building_id,building_code,building_name,alternate_building_names,latitude,longitude
-"",AAC,Architecture Annex Cambridge,"",43.35855,-80.31684
-"",AAR,Architecture Annex Rome,"",41.889615,12.470925
-"",ACW,Accelerator Centre Waterloo,"",43.47731,-80.54896
-"",IQC,Institute for Quantum Computing,"",43.47843,-80.55508
-145,WFF,Warrior Football Field,"",43.4747,-80.55014
-001,DWE,"Douglas Wright Engineering Building","",43.469981,-80.540042
-002,E2,"Engineering 2","",43.47104345,-80.54041224
-003,E3,"Engineering 3","",43.4717442,-80.54086285
-004,PHY,"Physics","",43.47071643,-80.54167824
-005,ML,"Modern Languages","",43.46909688,-80.54287987
-006,ESC,"Earth Sciences & Chemistry","",43.47134906,-80.54270285
-007,B1,"Biology 1","",43.47066971,-80.54305153
-008,LIB,"Dana Porter Library","DP",43.46984437,-80.54242926
-009,AL,"Arts Lecture Hall","",43.46894115,-80.54187136
-010,EV1,"Environment 1","",43.4683961,-80.54262238
-011,RCH,"J.R. Coutts Engineering Lecture Hall","",43.47031155,-80.54084139
-012,CSB,"Central Services Building","",43.47378801,-80.54366308
-013,B2,"Biology 2","",43.47076315,-80.54381328
-014,GSC,"General Services Complex","",43.47342207,-80.54308372
-015,COM,"Commissary","Police & Parking Services",43.47406051,-80.54290133
-016,SCH,"South Campus Hall","",43.46915917,-80.5405839
-017,MC,"Mathematics & Computer Building","",43.47207511,-80.54394739
-018,PAC,"Physical Activities Complex","",43.47242353,-80.54613339
-019,SLC,"Student Life Centre","",43.471601,-80.545455
-020,V1,"Student Village 1","Village 1",43.4716,-80.54996
-020,V1,V1 - East 1,"",43.471745,-80.549317
-020,V1,V1 - East 2,"",43.471821,-80.549017
-020,V1,V1 - East 3,"",43.47176,-80.548612
-020,V1,V1 - East 4,"",43.471568,-80.548526
-020,V1,V1 - East 5,"",43.471499,-80.548917
-020,V1,V1 - East 6,"",43.471443,-80.549304
-020,V1,V1 - North 1,"",43.47209,-80.55003
-020,V1,V1 - North 2,"",43.472284,-80.55023
-020,V1,V1 - North 3,"",43.47242,-80.54994
-020,V1,V1 - North 4,"",43.4725,-80.5496
-020,V1,V1 - North 5,"",43.47224,-80.54931
-020,V1,V1 - North 6,"",43.47205,-80.54956
-020,V1,V1 - South 1,"",43.471112,-80.549937
-020,V1,V1 - South 2,"",43.470865,-80.549891
-020,V1,V1 - South 3,"",43.470715,-80.550178
-020,V1,V1 - South 4,"",43.470614,-80.550481
-020,V1,V1 - South 5,"",43.470904,-80.550733
-020,V1,V1 - South 6,"",43.471087,-80.550478
-020,V1,V1 - South 7,"",43.47073,-80.55131
-020,V1,V1 - South 8,"",43.470919,-80.551554
-020,V1,V1 - West 1,"",43.471513,-80.550677
-020,V1,V1 - West 2,"",43.471457,-80.551063
-020,V1,V1 - West 3,"",43.471725,-80.551431
-020,V1,V1 - West 4,"",43.471902,-80.551192
-020,V1,V1 - West 5,"",43.472031,-80.550897
-020,V1,V1 - West 6,"",43.47183,-80.550647
-021,TH,"Tutors' Houses","",43.470546,-80.552748
-022,HS,"Health Services","",43.47058601,-80.54611194
-023,MHR,"Minota Hagey Residence","Velocity",43.46579535,-80.54275113
-024,HH,"J.G. Hagey Hall of the Humanities","Hagey Hall",43.46792891,-80.54165679
-025,REV,"Ron Eydt Village","",43.47015582,-80.55412369
-025,REV,REV - East A,"",43.469348,-80.553464
-025,REV,REV - East B,"",43.469348,-80.553464
-025,REV,REV - East C,"",43.469547,-80.552989
-025,REV,REV - East D,"",43.469547,-80.552989
-025,REV,REV - East E,"",43.469547,-80.552989
-025,REV,REV - North A,"",43.470777,-80.554
-025,REV,REV - North B,"",43.470777,-80.554
-025,REV,REV - North C,"",43.470526,-80.553539
-025,REV,REV - North D,"",43.470526,-80.553539
-025,REV,REV - North E,"",43.470526,-80.553539
-025,REV,REV - South A,"",43.469385,-80.554086
-025,REV,REV - South B,"",43.469385,-80.554086
-025,REV,REV - South C,"",43.469679,-80.554716
-025,REV,REV - South D,"",43.469679,-80.554716
-025,REV,REV - South E,"",43.469679,-80.554716
-025,REV,REV - West A,"",43.470806,-80.554609
-025,REV,REV - West B,"",43.470806,-80.554609
-025,REV,REV - West C,"",43.470579,-80.555062
-025,REV,REV - West D,"",43.470579,-80.555062
-025,REV,REV - West E,"",43.470579,-80.555062
-026,UWP,"University of Waterloo Place","UW Place",43.47064,-80.53584
-026,UWP,UWP - Beck Hall,"",43.470573,-80.534699
-026,UWP,UWP - Community Centre,"",43.4704,-80.53553
-026,UWP,UWP - Eby Hall,"",43.47067,-80.53512
-026,UWP,UWP - Waterloo Court,"",43.47007,-80.53492
-026,UWP,UWP - Wellesley Court,"",43.47155,-80.53564
-026,UWP,UWP - Wilmot Court,"",43.47111,-80.53666
-026,UWP,UWP - Woolwich Court,"",43.47064,-80.53354
-027,UC,"University Club","",43.472334,-80.547378
-028,C2,"Chemistry 2","",43.47209068,-80.54287451
-029,CPH,"Carl A. Pollock Hall","",43.47095002,-80.53933936
-030,PAS,"Psychology, Anthropology & Sociology","",43.46699451,-80.54251509
-031,NH,"Ira G. Needles Hall","Needles Hall",43.46962635,-80.54363089
-032,BMH,"B.C. Matthews Hall","",43.47386586,-80.54517584
-033,OPT,"School of Optometry & Vision Science","Optometry Building",43.47592517,-80.5455299
-034,EV2,"Environment 2","",43.46806907,-80.54335194
-035,FED,"Federation Hall","",43.47324689,-80.54864126
-036,ECH,"East Campus Hall","",43.47366343,-80.53864735
-037,DC,"William G. Davis Computer Research Centre","Davis Centre",43.472761,-80.542164
-038,BFG,"B.F. Goodrich Building","",43.47563, -80.54229
-039,EIT,"Centre for Environmental and Information Technology","CEIT",43.47149504,-80.54206448
-040,BAU,"Bauer Warehouse","",43.483354,-80.545715
-042,CIF,"Columbia Icefield","",43.47535682,-80.54852324
-043,CLV,"Columbia Lake Village","Columbia Lake Village South",43.47008185,-80.56183773
-043,CLV,CLV - Community Centre,"",43.470795,-80.562487
-043,CLV,CLV - Block A,"",43.470456,-80.5597
-043,CLV,CLV - Block B,"",43.470754,-80.560116
-043,CLV,CLV - Block C,"",43.47088,-80.559638
-043,CLV,CLV - Block D,"",43.470071,-80.560934
-043,CLV,CLV - Block E,"",43.470384,-80.561398
-043,CLV,CLV - Block F,"",43.470705,-80.561178
-043,CLV,CLV - Block G,"",43.4704,-80.560832
-043,CLV,CLV - Block H,"",43.46974,-80.561942
-043,CLV,CLV - Block I,"",43.469837,-80.562471
-043,CLV,CLV - Block J,"",43.470201,-80.562586
-043,CLV,CLV - Block K,"",43.470152,-80.562114
-043,CLV,CLV - Block L,"",43.469175,-80.563248
-043,CLV,CLV - Block M,"",43.469331,-80.56371
-043,CLV,CLV - Block N,"",43.469598,-80.563256
-044,MKV,"William Lyon Mackenzie King Village","Mackenzie King Village",43.471509,-80.552729
-044,MKV,MKV East,"",43.47132,-80.551983
-044,MKV,MKV West,"",43.471161,-80.553056
-045,TC,"William M. Tatham Centre for Co-operative Education & Career Action","Tatham Centre",43.469,-80.541324
-048,ERC,"Energy Research Centre","",43.4736245,-80.54447847
-051,RAC,"Research Advancement Centre","",43.47884,-80.55498
-052,IHB,"Integrated Health Building 1","",43.450981,-80.499828
-053,E5,"Engineering 5","",43.472953,-80.540085
-056,M3,"Mathematics 3","MC3",43.47302,-80.54448
-057,EV3,"Environment 3","",43.46745,-80.54319
-058,RA2,"Research Advancement Centre 2","",43.47863,-80.55553
-060,E6,"Engineering 6","",43.47301,-80.5389
-061,LHI,"Lyle S. Hallman Institute for Health Promotion","",43.47325857,-80.54589468
-062,BRH,"Brubacher House","",43.475571,-80.552348
-063,CGR,"Conrad Grebel University College","Conrad Grebel",43.46666747,-80.54541188
-064,CLN,"Columbia Lake Village North","CLV North",43.47207,-80.563
-064,CLN,CLN - Block 01,"",43.473547,-80.562819
-064,CLN,CLN - Block 02,"",43.473173,-80.562532
-064,CLN,CLN - Block 04,"",43.472426,-80.561728
-064,CLN,CLN - Block 05,"",43.472194,-80.561368
-064,CLN,CLN - Block 06,"",43.471896,-80.561191
-064,CLN,CLN - Block 07,"",43.471723,-80.561706
-064,CLN,CLN - Block 08,"",43.471536,-80.562194
-064,CLN,CLN - Block 09,"",43.471895,-80.562642
-064,CLN,CLN - Block 10,"",43.472243,-80.562618
-064,CLN,CLN - Block 11,"",43.472568,-80.562495
-064,CLN,CLN - Block 12,"",43.472251,-80.562130
-064,CLN,CLN - Block 13,"",43.472885,-80.562699
-064,CLN,CLN - Block 14,"",43.472447,-80.562964
-064,CLN,CLN - Block 15,"",43.472148,-80.563334
-064,CLN,CLN - Block 16,"",43.472081,-80.564050
-064,CLN,CLN - Block 17,"",43.472451,-80.563640
-064,CLN,CLN - Block 18,"",43.472652,-80.563315
-064,CLN,CLN - Block 19,"",43.473284,-80.563176
-064,CLN,CLN - Block 20,"",43.473000,-80.563490
-064,CLN,CLN - Block 21,"",43.472673,-80.563852
-064,CLN,CLN - Block 22,"",43.472356,-80.564235
-064,CLN,CLN - Block 23,"",43.471898,-80.564713
-064,CLN,CLN - Block 24,"",43.471659,-80.565011
-064,CLN,CLN - Block 25,"",43.471377,-80.565327
-064,CLN,CLN - Block 26,"",43.471194,-80.564995
-064,CLN,CLN - Block 27,"",43.471153,-80.564517
-064,CLN,CLN - Block 28,"",43.471268,-80.564050
-064,CLN,CLN - Block 29,"",43.471359,-80.563578
-064,CLN,CLN - Block 03,"",43.472739,-80.562125
-064,CLN,CLN - Block 30,"",43.471414,-80.562943
-064,CLN,CLN - Block 31,"",43.471719,-80.562948
-064,CLN,CLN - Block 32,"",43.471793,-80.563450
-064,CLN,CLN - Block 33,"",43.471606,-80.563895
-064,CLN,CLN - Block 34,"",43.471439,-80.564705
-064,CLN,CLN - Block 35,"",43.471850,-80.564235
-065,COG,"Columbia Greenhouses","",43.473218,-80.559405
-066,HMN,"Hildegard Marsden Nursery","",43.476478,-80.549349
-067,KDC,"Klemmer Day Care","",43.476023,-80.549178
-068,QNC,"Quantum Nano Centre","",43.471174,-80.544476
-069,STJ,"St. Jerome's University","St. Jerome's",43.46926818,-80.54588395
-070,STP,"St. Paul's University College","St. Paul's",43.467762,-80.546404
-071,REN,"Renison University College","Renison",43.46881657,-80.54762202
-104,GH,"Graduate House","Grad House",43.4696575,-80.54103451
-110,PHR,"School of Pharmacy","10 Victoria Street S, Kitchener, ON",43.450985,-80.499763
-111,ARC,"School of Architecture","7 Melville Street S, Cambridge, ON",43.358572,-80.31692
-132,GA,"Centre for Extended Learning","335 Gage Avenue, Kitchener, ON",43.44585,-80.5184
-133,HSC,"Huntsville Summit Center","87 Forbes Hill Drive, Huntsville, ON",45.32211,-79.20695
-134,WSS,"Stratford Campus","6 Wellington Street, Stratford, ON",43.370474,-80.982231
-155,180King,"180 King Street South, 7th Floor","180 King Street S, Kitchener, ON",43.46084,-80.51938
+1	DWE	Douglas Wright Engineering Building	43.469981	-80.540042
+2	E2	Engineering 2	43.47104345	-80.54041224
+3	E3	Engineering 3	43.4717442	-80.54086285
+4	PHY	Physics	43.47071643	-80.54167824
+5	ML	Modern Languages	43.46909688	-80.54287987
+6	ESC	Earth Sciences & Chemistry	43.47134906	-80.54270285
+7	B1	Biology 1	43.47066971	-80.54305153
+8	LIB	Dana Porter Arts Library	43.46984437	-80.54242926
+9	AL	Arts Lecture Hall	43.46894115	-80.54187136
+10	EV1	Environment 1	43.4683961	-80.54262238
+11	RCH	J.R. Coutts Engineering Lecture Hall	43.47031155	-80.54084139
+12	CSB	Central Services Building	43.47378801	-80.54366308
+13	B2	Biology 2	43.47076315	-80.54381328
+14	GSC	General Services Complex	43.47342207	-80.54308372
+15	COM	Commissary	43.47406051	-80.54290133
+16	SCH	South Campus Hall	43.46915917	-80.5405839
+17	MC	Mathematics & Computer Building	43.47207511	-80.54394739
+18	PAC	Physical Activities Complex	43.47242353	-80.54613339
+19	SLC	Student Life Centre	43.471601	-80.545455
+20CC	V1C	Student Village 1 Central Complex	43.4716	-80.54996
+20E1	VE1	Student Village 1 House East 1	43.471745	-80.549317
+20E2	VE2	Student Village 1 House East 2	43.471821	-80.549017
+20E3	VE3	Student Village 1 House East 3	43.47176	-80.548612
+20E4	VE4	Student Village 1 House East 4	43.471568	-80.548526
+20E5	VE5	Student Village 1 House East 5	43.471499	-80.548917
+20E6	VE6	Student Village 1 House East 6	43.471443	-80.549304
+20N1	VN1	Student Village 1 House North 1	43.47209	-80.55003
+20N2	VN2	Student Village 1 House North 2	43.472284	-80.55023
+20N3	VN3	Student Village 1 House North 3	43.47242	-80.54994
+20N4	VN4	Student Village 1 House North 4	43.4725	-80.5496
+20N5	VN5	Student Village 1 House North 5	43.47224	-80.54931
+20N6	VN6	Student Village 1 House North 6	43.47205	-80.54956
+20S1	VS1	Student Village 1 House South 1	43.471112	-80.549937
+20S2	VS2	Student Village 1 House South 2	43.470865	-80.549891
+20S3	VS3	Student Village 1 House South 3	43.470715	-80.550178
+20S4	VS4	Student Village 1 House South 4	43.470614	-80.550481
+20S5	VS5	Student Village 1 House South 5	43.470904	-80.550733
+20S6	VS6	Student Village 1 House South 6	43.471087	-80.550478
+20S7	VS7	Student Village 1 House South 7	43.47073	-80.55131
+20S8	VS8	Student Village 1 House South 8	43.470919	-80.551554
+20W1	VW1	Student Village 1 House West 1	43.471513	-80.550677
+20W2	VW2	Student Village 1 House West 2	43.471457	-80.551063
+20W3	VW3	Student Village 1 House West 3	43.471725	-80.551431
+20W4	VW4	Student Village 1 House West 4	43.471902	-80.551192
+20W5	VW5	Student Village 1 House West 5	43.472031	-80.550897
+20W6	VW6	Student Village 1 House West 6	43.47183	-80.550647
+21	TH	Tutors' Houses	43.470546	-80.552748
+22	HS	Health Services	43.47058601	-80.54611194
+23	MHR	Minota Hagey Residence	43.46579535	-80.54275113
+24	HH	J.G. Hagey Hall of the Humanities	43.46792891	-80.54165679
+25CC	REC	Ron Eydt Village Central Complex	43.47015582	-80.55412369
+25EA	VEA	Ron Eydt Village East A	43.469348	-80.553464
+25EB	VEB	Ron Eydt Village East B	43.469348	-80.553464
+25EC	VEC	Ron Eydt Village East C	43.469547	-80.552989
+25ED	VED	Ron Eydt Village East D	43.469547	-80.552989
+25EE	VEE	Ron Eydt Village East E	43.469547	-80.552989
+25EL	VEL	Ron Eydt Village East L	\N	\N
+25NA	VNA	Ron Eydt Village North A	43.470777	-80.554
+25NB	VNB	Ron Eydt Village North B	43.470777	-80.554
+25NC	VNC	Ron Eydt Village North C	43.470526	-80.553539
+25ND	VND	Ron Eydt Village North D	43.470526	-80.553539
+25NE	VNE	Ron Eydt Village North E	43.470526	-80.553539
+25NL	VNL	Ron Eydt Village North L	\N	\N
+25SA	VSA	Ron Eydt Village South A	43.469385	-80.554086
+25SB	VSB	Ron Eydt Village South B	43.469385	-80.554086
+25SC	VSC	Ron Eydt Village South C	43.469679	-80.554716
+25SD	VSD	Ron Eydt Village South D	43.469679	-80.554716
+25SE	VSE	Ron Eydt Village South E	43.469679	-80.554716
+25SL	VSL	Ron Eydt Village South L	\N	\N
+25WA	VWA	Ron Eydt Village West A	43.470806	-80.554609
+25WB	VWB	Ron Eydt Village West B	43.470806	-80.554609
+25WC	VWC	Ron Eydt Village West C	43.470579	-80.555062
+25WD	VWD	Ron Eydt Village West D	43.470579	-80.555062
+25WE	VWE	Ron Eydt Village West E	43.470579	-80.555062
+25WL	VWL	Ron Eydt Village West L	\N	\N
+26CC	UCC	UW Place Community Centre	43.4704	-80.53553
+26EC	UEC	UW Place Woolwich Court	43.47064	-80.53354
+26ET	UET	UW Place Beck Hall	43.470573	-80.534699
+26NC	UNC	UW Place Wellesley Court	43.47155	-80.53564
+26SC	USC	UW Place Waterloo Court	43.47007	-80.53492
+26WC	UWC	UW Place Wilmot Court	43.47111	-80.53666
+26WT	UWT	UW Place Eby Hall	43.47067	-80.53512
+27	UC	University Club	43.472334	-80.547378
+28	C2	Chemistry 2	43.47209068	-80.54287451
+29	CPH	Carl A. Pollock Hall	43.47095002	-80.53933936
+30	PAS	Psychology, Anthropology, Sociology	43.46699451	-80.54251509
+31	NH	Ira G. Needles Hall	43.46962635	-80.54363089
+32	BMH	B.C. Matthews Hall	43.47386586	-80.54517584
+33	OPT	Optometry	43.47592517	-80.5455299
+34	EV2	Environment 2	43.46806907	-80.54335194
+35	FED	Federation Hall	43.47324689	-80.54864126
+36	ECH	East Campus Hall	43.47366343	-80.53864735
+37	DC	William G. Davis Computer Research Centre	43.472761	-80.542164
+39	EIT	Centre for Environmental and Information Technology	43.47149504	-80.54206448
+40	BAU	Bauer Warehouse	43.483354	-80.545715
+41	COG	Columbia Greenhouses	43.473218	-80.559405
+42	CIF	Columbia Icefield	43.47535682	-80.54852324
+43A	CTA	Columbia Lake Village South Block A	43.470456	-80.5597
+43B	CTB	Columbia Lake Village South Block B	43.470754	-80.560116
+43C	CTC	Columbia Lake Village South Block C	43.47088	-80.559638
+43D	CTD	Columbia Lake Village South Block D	43.470071	-80.560934
+43E	CTE	Columbia Lake Village South Block E	43.470384	-80.561398
+43F	CTF	Columbia Lake Village South Block F	43.470705	-80.561178
+43G	CTG	Columbia Lake Village South Block G	43.4704	-80.560832
+43H	CTH	Columbia Lake Village South Block H	43.46974	-80.561942
+43J	CTJ	Columbia Lake Village South Block J	43.470201	-80.562586
+43K	CTK	Columbia Lake Village South Block K	43.470152	-80.562114
+43L	CTL	Columbia Lake Village South Block L	43.469175	-80.563248
+43M	CTM	Columbia Lake Village South Block M	43.469331	-80.56371
+43N	CTN	Columbia Lake Village South Block N	43.469598	-80.563256
+43P	CTP	Columbia Lake Village South Block P	\N	\N
+43Q	CTQ	Columbia Lake Village South Laundry	\N	\N
+44	MKV	William Lyon Mackenzie King Village	43.471509	-80.552729
+44E	MKE	William Lyon Mackenzie King Village East	43.47132	-80.551983
+44W	MKW	William Lyon Mackenzie King Village West	43.471161	-80.553056
+45	TC	William M. Tatham Centre for Co-operative Education & Career Services	43.469	-80.541324
+47	ARC	School of Architecture	43.358572	-80.31692
+48	ERC	Energy Research Centre	43.4736245	-80.54447847
+49	PHR	Pharmacy	43.452847	-80.49902
+50	QNC	Mike & Ophelia Lazaridis Quantum-Nano Centre	43.471174	-80.544476
+51	RAC	Research Advancement Centre	43.47884	-80.55498
+52	IHB	Integrated Health Building	43.452311	-80.499208
+53	E5	Engineering 5	43.472953	-80.540085
+54	STC	Science Teaching Complex	\N	\N
+55	DMS	Digital Media Stratford	\N	\N
+56	M3	Mathematics 3	43.47302	-80.54448
+57	EV3	Environment 3	43.46745	-80.54319
+58	RA2	Research Advancement Centre 2	43.47863	-80.55553
+59	ART	Arts Building	\N	\N
+60	E6	Engineering 6	43.47301	-80.5389
+61	TT	Tech Town	\N	\N
+62	BB1	175 Columbia St West	\N	\N
+63	BB2	185 Columbia St West	\N	\N
+64	BB3	195 Columbia St West	\N	\N
+65	BB4	295 Phillip St	\N	\N
+66	BB5	305 Phillip St	\N	\N
+67	E7	Engineering 7	\N	\N
+68	NRB	New Residence Building	\N	\N
+69	ST2	Science Teaching 2	\N	\N
+85	TUN	Service Tunnels	\N	\N
+87	GST	Ground Storage Building V2	\N	\N
+88	KKS	Kiosks 1, 2, 3, 4, & 5	\N	\N
+89	EV	Electrical Vault	\N	\N
+90	MV	Mechanical Vault	\N	\N
+93	POV	Pedestrian Overpass	\N	\N
+94	PT	Pedestrian Tunnels	\N	\N
+95	TEN	Tennis Courts	\N	\N
+100	SGR	Schmidt Greenhouse	\N	\N
+104	GH	Graduate House	43.4696575	-80.54103451
+106	DB	Dearborn Pumphouse	\N	\N
+112	BRH	Brubacher House	43.475571	-80.552348
+115	KDC	Klemmer Farmhouse Cooperative Nursery Inc.	43.476023	-80.549178
+123	HMN	Hildegard-Marsden Co-operative Day Nursery	43.476478	-80.549349
+124	BEG	BEG Test Building	\N	\N
+125	AN3	145 Columbia	\N	\N
+128	TUL	Tri-University Library	\N	\N
+129	AB	Aberfoyle Building	\N	\N
+130	AH	Aberfoyle House	\N	\N
+131	AS	Aberfoyle Storage	\N	\N
+132	GA	335 Gage Avenue	43.44585	-80.5184
+134	KGC	KW Garden Club	\N	\N
+135	FRF	Fire Research Facility	\N	\N
+136	PTB	Pavement & Transportation Technology Building	\N	\N
+137	PTG	Pavement & Transportation Technology Garage	\N	\N
+138	VS	Victoria School	\N	\N
+139	VSS	68 Victoria Street South	\N	\N
+140	AAR	Architecture Annex Rome	\N	\N
+144	ACW	Accelerator Centre Waterloo	\N	\N
+145	WFF	Warrior Football Field	43.4747	-80.55014
+149	KSW	195 King Street West	\N	\N
+150	HSC	Huntsville Summit Centre	45.32211	-79.20695
+151	UAE	United Arab Emirates Dubai	\N	\N
+152	WSS	6 Wellington Street, Stratford	43.370474	-80.982231
+153	UWD	University of Waterloo Daycare	\N	\N
+155	ASA	Allen Square Arts	\N	\N
+156	CIG	Centre for International Governance & Innovation (BSIA)	\N	\N
+158	CHB	Communitech Hub Building	\N	\N
+159	GSK	44 Gaukel Street, Kitchener	\N	\N
+160	WCP	Waterloo Central Place	\N	\N
+161	BSK	Breithaupt Street Kitchener	\N	\N
+162	MTT	Master of Taxation Toronto	\N	\N
+801	SHO	St. Jerome's University Sweeney Hall	43.46926818	-80.54588395
+802	SHA	St. Jerome's University Sweeney Hall Addition	43.46926818	-80.54588395
+811	STJ	St. Jerome's University Finn Residence	43.46926818	-80.54588395
+812	STJ	St. Jerome's University Louis Hall	43.46926818	-80.54588395
+813	STJ	St. Jerome's University Classroom Building	43.46926818	-80.54588395
+814	STJ	St. Jerome's University Library Addition	43.46926818	-80.54588395
+815	STJ	St. Jerome's University Siegfried Hall	43.46926818	-80.54588395
+821	REN	Renison University College Original Building	43.46881657	-80.54762202
+822	REN	Renison University College Addition	43.46881657	-80.54762202
+823	REN	Renison University College Addition 2 - Chapel	43.46881657	-80.54762202
+824	REN	Renison University College Addition 3 - Link	43.46881657	-80.54762202
+825	REN	Renison University College Addition 4 - Academic Centre	43.46881657	-80.54762202
+831	STP	St. Paul's United College Main Building	43.467762	-80.546404
+832	STP	St. Paul's United College West Wing	43.467762	-80.546404
+833	STP	St. Paul's United College East Wing	43.467762	-80.546404
+834	STP	St. Paul's United College Graduate Apartment	43.467762	-80.546404
+835	STP	St. Paul's United College North Wing	43.467762	-80.546404
+841	CGR	Conrad Grebel University College Residence	43.46666747	-80.54541188
+842	CGR	Conrad Grebel University College Administration Building	43.46666747	-80.54541188
+843	CGR	Conrad Grebel University College Residence Addition	43.46666747	-80.54541188
+844	CGR	Conrad Grebel University College Administration Addition	43.46666747	-80.54541188
+845	CGR	Conrad Grebel University College Apartments	43.46666747	-80.54541188
+4601	L01	Columbia Lake Village North Block 1	43.473547	-80.562819
+4602	L02	Columbia Lake Village North Block 2	43.473173	-80.562532
+4603	L03	Columbia Lake Village North Block 3	43.472739	-80.562125
+4604	L04	Columbia Lake Village North Block 4	43.472426	-80.561728
+4605	L05	Columbia Lake Village North Block 5	43.472194	-80.561368
+4606	L06	Columbia Lake Village North Block 6	43.471896	-80.561191
+4607	L07	Columbia Lake Village North Block 7	43.471723	-80.561706
+4608	L08	Columbia Lake Village North Block 8	43.471536	-80.562194
+4609	L09	Columbia Lake Village North Block 9	43.471895	-80.562642
+4610	L10	Columbia Lake Village North Block 10	43.472243	-80.562618
+4611	L11	Columbia Lake Village North Block 11	43.472568	-80.562495
+4612	L12	Columbia Lake Village North Block 12	43.472251	-80.56213
+4613	L13	Columbia Lake Village North Block 13	43.472885	-80.562699
+4614	L14	Columbia Lake Village North Block 14	43.472447	-80.562964
+4615	L15	Columbia Lake Village North Block 15	43.472148	-80.563334
+4616	L16	Columbia Lake Village North Block 16	43.472081	-80.56405
+4617	L17	Columbia Lake Village North Block 17	43.472451	-80.56364
+4618	L18	Columbia Lake Village North Block 18	43.472652	-80.563315
+4619	L19	Columbia Lake Village North Block 19	43.473284	-80.563176
+4620	L20	Columbia Lake Village North Block 20	43.473	-80.56349
+4621	L21	Columbia Lake Village North Block 21	43.472673	-80.563852
+4622	L22	Columbia Lake Village North Block 22	43.472356	-80.564235
+4623	L23	Columbia Lake Village North Block 23	43.471898	-80.564713
+4624	L24	Columbia Lake Village North Block 24	43.471659	-80.565011
+4625	L25	Columbia Lake Village North Block 25	43.471377	-80.565327
+4626	L26	Columbia Lake Village North Block 26	43.471194	-80.564995
+4627	L27	Columbia Lake Village North Block 27	43.471153	-80.564517
+4628	L28	Columbia Lake Village North Block 28	43.471268	-80.56405
+4629	L29	Columbia Lake Village North Block 29	43.471359	-80.563578
+4630	L30	Columbia Lake Village North Block 30	43.471414	-80.562943
+4631	L31	Columbia Lake Village North Block 31	43.471719	-80.562948
+4632	L32	Columbia Lake Village North Block 32	43.471793	-80.56345
+4633	L33	Columbia Lake Village North Block 33	43.471606	-80.563895
+4634	L34	Columbia Lake Village North Block 34	43.471439	-80.564705
+4635	L35	Columbia Lake Village North Block 35	43.47185	-80.564235


### PR DESCRIPTION
Note that alternate_building_names column has been dropped (does not appear in IAP sources) and the file format has been changed to tab delimited with \N for nulls.
